### PR TITLE
minor fixes to dev-instructions

### DIFF
--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -34,17 +34,18 @@ The easiest & safest way to develop & test TLJH is with `Docker <https://www.doc
 
       sudo docker exec -it tljh-dev /bin/bash
 
-#. Run the installer! The container image is already set up to default to a
-   ``dev`` install, so it'll install from your local repo rather than from github.
+#. Run the installer from inside the container (see step above): 
+   The container image is already set up to default to a ``dev`` install, so 
+   it'll install from your local repo rather than from github.
 
    .. code-block:: console
 
-      # bash /srv/src/installer/install.bash
+      bash /srv/src/installer/install.bash
 
    The primary hub environment will also be in your PATH already for convenience.
 
 #. You should be able to access the JupyterHub from your browser now at
-   `http://localhost:1200 <http://localhost:12000>`_. Congratulations, you are
+   `http://localhost:12000 <http://localhost:12000>`_. Congratulations, you are
    set up to develop TLJH!
 
 #. Make some changes to the repository. You can test easily depending on what


### PR DESCRIPTION
The dev install instructions are great @yuvipanda and worked nicely!

I just edited two minor things: 
- clarified where/how to run the `install` script (the one before would not be cope & paste-able) 
- fixed the port for the running JupyterHub location, so that the displayed port matches the link itself